### PR TITLE
Fix CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
-on: [push, pull_request, pull_request_target]
+on:
+  pull_request: ~
 
 jobs:
   unit-tests:
@@ -21,4 +22,3 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Check files formatting
         run: cargo fmt --check
-        


### PR DESCRIPTION
Only the `pull_request` trigger is needed in our case. see https://github.com/onlydustxyz/starklings/blob/main/.github/workflows/test.yml#L4
This will be run on pull requests and pull requests coming from forks