### PR TITLE
refactor: run cargo clippy --fix -- -W clippy::nursery

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -61,9 +61,9 @@ impl fmt::Display for Output {
 impl CommandExecution<Output> for Commands {
 	fn exec(&self) -> Result<Output, String> {
 		match &self {
-			Commands::List(args) => args.exec().map(|o| Output(CommandOutputs::List(o))),
-			Commands::Execute(args) => args.exec().map(|o| Output(CommandOutputs::Execute(o))),
-			Commands::Test(args) => args.exec().map(|o| Output(CommandOutputs::Test(o))),
+			Self::List(args) => args.exec().map(|o| Output(CommandOutputs::List(o))),
+			Self::Execute(args) => args.exec().map(|o| Output(CommandOutputs::Execute(o))),
+			Self::Test(args) => args.exec().map(|o| Output(CommandOutputs::Test(o))),
 		}
 	}
 }

--- a/src/cli/commands/test/mod.rs
+++ b/src/cli/commands/test/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn test_single_entrypoint(
 	let execution_uuid = Uuid::new_v4();
 	init_buffer(execution_uuid);
 	let res_cairo_run = cairo_run(
-		&path_to_compiled,
+		path_to_compiled,
 		&test_entrypoint,
 		false,
 		false,
@@ -234,7 +234,7 @@ fn run_tests_for_one_file(
 			test_single_entrypoint(
 				&path_to_compiled,
 				test_entrypoint,
-				&hint_processor,
+				hint_processor,
 				Some(hooks.clone()),
 			)
 		})


### PR DESCRIPTION
Just a simple lint apply: `cargo clippy --fix -- -W clippy::nursery`